### PR TITLE
fix(go-test): add space between cmd and path

### DIFF
--- a/lua/nvim-test/runners/go-test.lua
+++ b/lua/nvim-test/runners/go-test.lua
@@ -19,8 +19,10 @@ function gotest:build_args(filename, opts)
     return args .. " ./..."
   end
 
-  local path = "./" .. vim.fn.fnamemodify(filename, ":.:h")
-  args = args .. ((path == "./.") and "" or (path .. "/..."))
+  local path = vim.fn.fnamemodify(filename, ":.:h")
+  if path ~= "." then
+    args = string.format("%s ./%s/...", args, path)
+  end
   if opts.tests then
     args = string.format(" -run %s ", vim.fn.shellescape(opts.tests[1] .. "$")) .. args
   end

--- a/spec/lua/test/go-test_spec.lua
+++ b/spec/lua/test/go-test_spec.lua
@@ -1,13 +1,16 @@
 local helpers = require "spec.lua.helpers"
 
 describe("gotest", function()
+  local pwd
+
   before_each(function()
     helpers.before_each()
+    pwd = vim.fn.getcwd()
     vim.api.nvim_command "cd spec/lua/test/fixtures/go"
   end)
   after_each(function()
     helpers.after_each()
-    vim.api.nvim_command "cd -"
+    vim.api.nvim_command("cd " .. pwd)
   end)
 
   local filename = "mypackage_test.go"
@@ -22,6 +25,13 @@ describe("gotest", function()
     helpers.view(filename)
     vim.api.nvim_command "TestFile"
     assert.are.equal(vim.g.test_latest.cmd, "go test")
+  end)
+
+  it("run nested file", function()
+    helpers.view(filename)
+    vim.api.nvim_command "cd ../"
+    vim.api.nvim_command "TestFile"
+    assert.are.equal(vim.g.test_latest.cmd, "go test ./go/...")
   end)
 
   it("run nearest function", function()


### PR DESCRIPTION
For `go-test` runner, when running the `TestFile` command for a file
which is in a directory nested inside the current working directory,
there's a space missing between the command and file path.

Running the newly added test case without the fix would produce:
```
go test./go/...
       ^
       Here, a space is missing
```

### Test Update

As there's a need to `cd` inside the test case, we cannot just use the `cd -` command. Instead, the current working directory will be stored in a global variable `pwd` and the `after_each` function will use that to `cd` back.