### PR TITLE
Change `Haskel` to `Haskell`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Test Runner for neovim
 | -------------: | :------------------------------- |
 | **C Sharp**    | `dotnet test`                    |
 | **Go**         | `go-test`                        |
-| **Haskel**     | `hspec`, `stack`                 |
+| **Haskell**    | `hspec`, `stack`                 |
 | **Javascript** | `jest`, `mocha`                  |
 | **Lua**        | `busted`, `vusted`               |
 | **Python**     | `pytest`, `pyunit`               |


### PR DESCRIPTION
I stumbled upon this minor typo that I thought might be worth fixing.