### PR TITLE
fix: use the correct filetype for javascriptreact

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ require('nvim-test').setup {
     cs = "nvim-test.runners.dotnet",
     go = "nvim-test.runners.go-test",
     haskell = "nvim-test.runners.hspec",
-    javacriptreact = "nvim-test.runners.jest",
+    javascriptreact = "nvim-test.runners.jest",
     javascript = "nvim-test.runners.jest",
     lua = "nvim-test.runners.busted",
     python = "nvim-test.runners.pytest",

--- a/lua/nvim-test/runners/init.lua
+++ b/lua/nvim-test/runners/init.lua
@@ -2,7 +2,7 @@ return {
   cs = "nvim-test.runners.dotnet",
   go = "nvim-test.runners.go-test",
   haskell = "nvim-test.runners.hspec",
-  javacriptreact = "nvim-test.runners.jest",
+  javascriptreact = "nvim-test.runners.jest",
   javascript = "nvim-test.runners.jest",
   lua = "nvim-test.runners.busted",
   python = "nvim-test.runners.pytest",


### PR DESCRIPTION
First of all, thanks for such a handy plugin :-)

This PR fixes a problem I found while working with a `javascriptreact` file. It is just a typo (a
missing 's') that causes the runner to not be assigned to that kind of files.

As a workaround, you can just set the proper value in your call to the `setup` function:

```lua

test.setup {
  -- other options...
  runners = {
    javascriptreact = "nvim-test.runners.jest"
  }
}
```

I hope it helps.

Thanks!
