### PR TITLE
rust tests with `#[test]`

### DIFF
--- a/lua/nvim-test/runners/cargo-test.lua
+++ b/lua/nvim-test/runners/cargo-test.lua
@@ -1,23 +1,23 @@
--- TODO
---
+local ts = vim.treesitter
+local ts_parsers = require("nvim-treesitter.parsers")
+local ts_utils = require "nvim-treesitter.ts_utils"
+
 local Runner = require "nvim-test.runner"
 
 local cargotest = Runner:init({ command = "cargo", args = { "test" }, package = false }, {
   rust = [[
-      (
-        (
-          mod_item name: (identifier) @test-name
-          (#match? @test-name "[Tt]est")
-        )
-      @scope-root)
+  (
+    mod_item name: (identifier) @mod-name
+    (#match? @mod-name "[Tt]est")
+  )
 
-      (
-        (
-          function_item name: (identifier) @test-name
-          (#match? @test-name "[Tt]est")
-        )
-      @scope-root)
-    ]],
+  (
+    (
+      (attribute_item (attribute (identifier) @attr-name))
+      (function_item name: (identifier) @test-name) @fun
+    ) @scope-root
+  )
+  ]]
 })
 
 function cargotest:build_args(args, filename, opts)
@@ -55,4 +55,46 @@ function cargotest:build_args(args, filename, opts)
   end
 end
 
+function cargotest:find_nearest_test(filetype)
+  local query = ts.get_query(ts_parsers.ft_to_lang(filetype), "nvim-test")
+
+  local found_func = false
+  local found_test = false
+  local found_mod = false
+  local result = {}
+  local curnode = ts_utils.get_node_at_cursor()
+  if not curnode then
+    return result
+  end
+
+  local curLine, _, _, _ = curnode:range()
+
+  while curnode do
+    for capture_id, capture_node, _ in query:iter_captures(curnode, 0) do
+      local start_node, _, end_node, _ = capture_node:range()
+      if query.captures[capture_id] == "fun" and start_node <= curLine and
+          end_node >= curLine then
+        found_func = true
+      end
+
+      if query.captures[capture_id] == "test-name" and found_func and not found_test then
+        local name = self:parse_testname(ts.query.get_node_text(capture_node, 0))
+        table.insert(result, name)
+        found_test = true
+      end
+
+      if query.captures[capture_id] == "mod-name" and not found_mod then
+        local name = self:parse_testname(ts.query.get_node_text(capture_node, 0))
+        table.insert(result, 1, name)
+        found_mod = true
+      end
+    end
+
+    curnode = curnode:parent()
+  end
+
+  return result
+end
+
 return cargotest
+


### PR DESCRIPTION
Hi,

I have been trying to get nvim-test to run rust tests that do not have `test` in the name but that are annotated with `#[test]`

```rust

fn add(a: i32, b: i32) -> i32 {
    a + b
}

#[cfg(test)]
mod tests {
    use super::*;

    fn not_a_test() {
        assert_eq!(1, 2);
    }

    #[test]
    fn test_add3() {
        assert_eq!(add(1, 2), 3);
    }

    #[test]
    fn test_add5() {
        assert_eq!(add(3, 2), 5);
    }

    fn foo() {
        println!("{}", 'a' as u32);
    }

    #[test]
    fn test_ascii() {
        println!("{}", 'a' as u32);
        println!("{}", 'A' as u32);
    }
    #[test]
    fn bar() {
        println!("{}", 'a' as u32);
        println!("{}", 'A' as u32);
    }
}

mod foo {
    fn foobar() {
        println!("{}", 'a' as u32);
        println!("{}", 'A' as u32);
    }
}
```

I'm brand new to treesitter, and lua (and to rust too actually). Took me a while because you need an expression that matches a sibling from the function you are trying to find. I think you can't solve it by just fiddling with the treesitter expression and use the generic `find_nearest_test` of the `Runner` but I'm not sure at all.

I have tried a first implementation that works on the above example but I'm not very happy with it. I don't like the booleans that track the state of whether I have already found my targets and such, and I also guess that it might not work with other test patterns.

Questions
- Are you interested in solving the problem (test tagged and not following a naming convention)
- Any pointers you might give me?

(I have now seen that there are specs test, I'll need to try and run them too, I have not done that yet)