### PR TITLE
Compatibility with neovim 0.9+

### DIFF
--- a/lua/nvim-test/runner.lua
+++ b/lua/nvim-test/runner.lua
@@ -19,7 +19,7 @@ function Runner:init(config, queries)
   self = setmetatable({}, Runner)
   self.queries = queries or {}
   for ft, query in pairs(self.queries) do
-    ts.set_query(ft, "nvim-test", query)
+    ts.query.set(ft, "nvim-test", query)
   end
   self:setup(config)
   return self
@@ -36,7 +36,7 @@ function Runner:setup(config)
 end
 
 function Runner:find_nearest_test(filetype)
-  local query = ts.get_query(ts_parsers.ft_to_lang(filetype), "nvim-test")
+  local query = ts.query.get(ts_parsers.ft_to_lang(filetype), "nvim-test")
   local result = {}
   if query then
     local curnode = ts_utils.get_node_at_cursor()

--- a/lua/nvim-test/runner.lua
+++ b/lua/nvim-test/runner.lua
@@ -50,7 +50,7 @@ function Runner:find_nearest_test(filetype)
             return result
           end
         end
-        local name = self:parse_testname(ts.query.get_node_text(capture_node, 0))
+        local name = self:parse_testname(ts.get_node_text(capture_node, 0))
         table.insert(result, 1, name)
       end
       curnode = curnode:parent()


### PR DESCRIPTION
I actually did not check  when this syntax was introduced. However, 0.9 raises warnings, and 0.10 will completely remove the old syntax