### PR TITLE
Fix TestNearest with Jest on TSX TS Language

### DIFF
--- a/lua/nvim-test/runners/jest.lua
+++ b/lua/nvim-test/runners/jest.lua
@@ -21,6 +21,7 @@ local jest = Runner:init({
 }, {
   javascript = query,
   typescript = query,
+  tsx        = query,
 })
 
 function jest:parse_testname(name)


### PR DESCRIPTION
### Issue

When you have the treesitter `tsx` language installed (or gets automatically installed in my case) the `:TestNearest` fails due to `ft_to_lang(filetype)` returning `tsx` and not `typescript` finding no matching query for the runner. This short circuits and returns `{}` and runs tests against the whole file.

### Solution

- Add `tsx` to list of languages jest runner 

Not sure how to run any of the tests locally to ensure there are no breaking changes but looking at the jest runner spec there doesn't appear anything this would break.