### PR TITLE
Add float_position configuration setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ require('nvim-test').setup {
   term = "terminal",          -- a terminal to run ("terminal"|"toggleterm")
   termOpts = {
     direction = "vertical",   -- terminal's direction ("horizontal"|"vertical"|"float")
+    float_position = "center" -- vertical position of the float window ("center"|"top"|"bottom")
     width = 96,               -- terminal's width (for vertical|float)
     height = 24,              -- terminal's height (for horizontal|float)
     go_back = false,          -- return focus to original window after executing

--- a/doc/nvim-test.txt
+++ b/doc/nvim-test.txt
@@ -42,6 +42,7 @@ Setup the plugin (default values): >
     term = "terminal",          -- a terminal to run ("terminal"|"toggleterm")
     termOpts = {
       direction = "vertical",   -- terminal's direction ("horizontal"|"vertical"|"float")
+      float_position = "center" -- vertical position of the float window ("center"|"top"|"bottom")
       width = 96,               -- terminal's width (for vertical|float)
       height = 24,              -- terminal's height (for horizontal|float)
       go_back = false,          -- return focus to original window after executing

--- a/lua/nvim-test/config.lua
+++ b/lua/nvim-test/config.lua
@@ -9,6 +9,7 @@ return {
   term = "terminal",          -- a terminal to run ("terminal"|"toggleterm")
   termOpts = {
     direction = "vertical",   -- terminal's direction ("horizontal"|"vertical"|"float")
+    float_position = "center", -- vertical position of the float window ("center"|"top"|"bottom")
     width = 96,               -- terminal's width (for vertical|float)
     height = 24,              -- terminal's height (for horizontal|float)
     go_back = false,          -- return focus to original window after executing

--- a/lua/nvim-test/init.lua
+++ b/lua/nvim-test/init.lua
@@ -124,6 +124,7 @@ function M.run_cmd(cmd, cfg)
     width = { opts.width, "number" },
     height = { opts.height, "number" },
     go_back = { opts.go_back, "boolean" },
+    float_position = { opts.float_position, "string" },
     -- stopinsert = { opts.stopinsert, "boolean" },
   }
   return termExec(cmd, cfg, opts)

--- a/lua/nvim-test/terms/terminal.lua
+++ b/lua/nvim-test/terms/terminal.lua
@@ -24,7 +24,9 @@ return function(cmd, cfg, termCfg)
   if termCfg.direction == "float" then
     local bufnr = vim.api.nvim_create_buf(false, false)
     vim.api.nvim_open_win(bufnr, true, {
-      row = math.ceil(vim.o.lines - termCfg.height) / 2 - 1,
+      row = termCfg.float_position == "top" and 0
+        or termCfg.float_position == "bottom" and math.ceil(vim.o.lines - termCfg.height) - 3
+        or math.ceil(vim.o.lines - termCfg.height) / 2 - 1,
       col = math.ceil(vim.o.columns - termCfg.width) / 2 - 1,
       relative = "editor",
       width = termCfg.width,


### PR DESCRIPTION
Hi, great plugin!

A lot of times I need to compare the test output with some variables in the code and the float window get in the way. This simple commit add the `float_position` configuration setting inside `termOpts` to change the vertical position of the float window.
The supported values are `top` and `bottom`. Any other value like `center` will default to the center position.

I'm making the PR in case this is useful to someone else.
Regards